### PR TITLE
Add remaining card counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
             <p>Haz clic para empezar y robar una carta</p>
         </div>
 
+        <p id="card-count">Cartas restantes: 0</p>
+
         <div id="active-card" class="card hidden">
             <span id="card-action"></span>
         </div>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const completeButton = document.getElementById('complete-btn');
     const winMessageElement = document.getElementById('win-message');
     const restartButton = document.getElementById('restart-btn');
+    const cardCountElement = document.getElementById('card-count');
 
     // --- Definición de las cartas ---
     const cardActions = [
@@ -44,6 +45,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function updateCardCount() {
+        const total = playerDeck.length + (currentCard ? 1 : 0);
+        cardCountElement.textContent = `Cartas restantes: ${total}`;
+    }
+
     // --- Funciones del Juego ---
 
     /**
@@ -71,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
             activeCardElement.classList.add('hidden');
             actionButtons.classList.add('hidden');
             winMessageElement.classList.remove('hidden');
+            cardCountElement.textContent = 'Cartas restantes: 0';
             return;
         }
 
@@ -84,6 +91,8 @@ document.addEventListener('DOMContentLoaded', () => {
         deckElement.classList.add('hidden');
         activeCardElement.classList.remove('hidden');
         actionButtons.classList.remove('hidden');
+
+        updateCardCount();
     }
 
     /**
@@ -137,6 +146,7 @@ document.addEventListener('DOMContentLoaded', () => {
         activeCardElement.classList.add('hidden');
         actionButtons.classList.add('hidden');
         deckElement.classList.remove('hidden');
+        updateCardCount();
     }
 
 

--- a/style.css
+++ b/style.css
@@ -140,3 +140,8 @@ button {
 .hidden {
     display: none !important;
 }
+
+#card-count {
+    margin-top: 10px;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add card count display to HTML
- style card counter
- track deck size in JS and update counter

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68482d946ea8832799cbeceea50d97ed