### PR TITLE
Update button layout and remove extra emoji

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,8 +31,6 @@ document.addEventListener('DOMContentLoaded', () => {
         "choca esos 5": "🤚✋",
         "puños de atún": "🤜🤛",
         "atún feliz": "🐟😀",
-        "cambio": "♻️"
-
     };
 
     let playerDeck = [];

--- a/style.css
+++ b/style.css
@@ -229,9 +229,10 @@ h1 {
 
 /* Estilos para los botones */
 #action-buttons {
-    margin-top: 20px;
+    margin-top: 10px;
     display: flex;
-    justify-content: space-around;
+    justify-content: center;
+    gap: 1rem;
 }
 
 button {
@@ -245,11 +246,11 @@ button {
 }
 
 #pass-btn {
-    background-color: #777;
+    background-color: #dc3545;
     color: white;
 }
 #pass-btn:hover {
-    background-color: #555;
+    background-color: #c82333;
 }
 
 #complete-btn {


### PR DESCRIPTION
## Summary
- center action buttons and space them closer to the card
- make the pass button red
- remove the recycle emoji from the change card text

## Testing
- `npx prettier --check "**/*.{js,css,html}"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848363a35008327ba07029daed856f7