### PR TITLE
Enable disabling Cambio cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
             <span>Haz clic para empezar y robar una carta</span>
         </div>
 
+        <button id="change-toggle-btn">Cambios SÍ</button>
+
         <p id="card-count">Cartas restantes: 0</p>
 
         <div id="active-card" class="card hidden">

--- a/script.js
+++ b/script.js
@@ -11,6 +11,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const winMessageElement = document.getElementById('win-message');
     const restartButton = document.getElementById('restart-btn');
     const cardCountElement = document.getElementById('card-count');
+    const changeToggleButton = document.getElementById('change-toggle-btn');
+
+    let includeChangeCards = true;
 
     // --- Definición de las cartas ---
     const cardActions = [
@@ -66,8 +69,9 @@ document.addEventListener('DOMContentLoaded', () => {
      */
     function createAndShuffleDeck() {
         playerDeck = [];
+        const actions = includeChangeCards ? cardActions : cardActions.filter(a => a !== "Cambio");
         for (let i = 0; i < 3; i++) {
-            playerDeck.push(...cardActions);
+            playerDeck.push(...actions);
         }
 
         // Algoritmo de barajado (Fisher-Yates)
@@ -88,6 +92,11 @@ document.addEventListener('DOMContentLoaded', () => {
             winMessageElement.classList.remove('hidden');
             cardCountElement.textContent = 'Cartas restantes: 0';
             return;
+        }
+
+        // Oculta el botón de cambios al comenzar la partida
+        if (currentCard === null) {
+            changeToggleButton.classList.add('hidden');
         }
 
         // Saca la primera carta del mazo
@@ -157,6 +166,9 @@ document.addEventListener('DOMContentLoaded', () => {
         activeCardElement.classList.add('hidden');
         actionButtons.classList.add('hidden');
         deckElement.classList.remove('hidden');
+        changeToggleButton.classList.remove('hidden');
+        changeToggleButton.disabled = false;
+        changeToggleButton.textContent = includeChangeCards ? 'Cambios SÍ' : 'Cambios NO';
         updateCardCount();
     }
 
@@ -166,6 +178,12 @@ document.addEventListener('DOMContentLoaded', () => {
     completeButton.addEventListener('click', handleComplete);
     passButton.addEventListener('click', handlePass);
     restartButton.addEventListener('click', startGame);
+    changeToggleButton.addEventListener('click', () => {
+        includeChangeCards = !includeChangeCards;
+        changeToggleButton.textContent = includeChangeCards ? 'Cambios SÍ' : 'Cambios NO';
+        createAndShuffleDeck();
+        updateCardCount();
+    });
 
     // --- Iniciar el juego por primera vez ---
     startGame();

--- a/style.css
+++ b/style.css
@@ -266,6 +266,16 @@ button {
     color: white;
 }
 
+/* Botón para activar o desactivar cartas de Cambio */
+#change-toggle-btn {
+    margin-top: 10px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: #ffd166;
+    color: #333;
+}
+
 /* Clase de utilidad para ocultar elementos */
 .hidden {
     display: none !important;


### PR DESCRIPTION
## Summary
- add button for enabling/disabling Cambio cards before the game starts
- style toggle button
- implement toggle logic in game script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684836ab15bc83278e0942fc5c3c03a7