### PR TITLE
Random deck color

### DIFF
--- a/script.js
+++ b/script.js
@@ -57,6 +57,16 @@ document.addEventListener('DOMContentLoaded', () => {
         cardCountElement.textContent = `Cartas restantes: ${total}`;
     }
 
+    /**
+     * Devuelve un color RGB aleatorio.
+     */
+    function randomColor() {
+        const r = Math.floor(Math.random() * 256);
+        const g = Math.floor(Math.random() * 256);
+        const b = Math.floor(Math.random() * 256);
+        return `rgb(${r}, ${g}, ${b})`;
+    }
+
     // --- Funciones del Juego ---
 
     /**
@@ -151,6 +161,10 @@ document.addEventListener('DOMContentLoaded', () => {
     function startGame() {
         createAndShuffleDeck();
         currentCard = null;
+
+        const playerColor = randomColor();
+        deckElement.style.backgroundColor = playerColor;
+        deckElement.style.borderColor = playerColor;
         winMessageElement.classList.add('hidden');
         activeCardElement.classList.add('hidden');
         actionButtons.classList.add('hidden');


### PR DESCRIPTION
## Summary
- create `randomColor` utility function
- set deck background and border to a random color whenever the game starts

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848386a2f408327b5dd6c3c6d979786