### PR TITLE
Fix tooltip layering

### DIFF
--- a/style.css
+++ b/style.css
@@ -293,6 +293,7 @@ button {
     display: inline-block;
     cursor: help;
     margin-left: 8px;
+    z-index: 100;
 }
 
 .tooltip-text {
@@ -304,7 +305,7 @@ button {
     border-radius: 6px;
     padding: 5px;
     position: absolute;
-    z-index: 1;
+    z-index: 200;
     top: 125%;
     left: 50%;
     transform: translateX(-50%);


### PR DESCRIPTION
## Summary
- ensure tooltip appears above cards by raising z-index on `.tooltip` and `.tooltip-text`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68483df2404c8327ac166beac3ff0746